### PR TITLE
makeSearchMapとmakeMap2の順番を変更

### DIFF
--- a/uROS_STEP8_micromouse/map_manager.h
+++ b/uROS_STEP8_micromouse/map_manager.h
@@ -55,8 +55,8 @@ private:
   t_position mypos;
   short goal_mx, goal_my;
 
-  void makeMap2(int x, int y);
   void makeSearchMap(int x, int y);
+  void makeMap2(int x, int y);
   int getPriority(unsigned char x, unsigned char y, t_direction_glob dir);
 };
 

--- a/uROS_STEP8_micromouse/map_manager.ino
+++ b/uROS_STEP8_micromouse/map_manager.ino
@@ -471,62 +471,6 @@ t_direction MapManager::getNextDir2(short x, short y, t_direction_glob * dir)
   return front;
 }
 
-void MapManager::makeMap2(int x, int y)
-{
-  bool change_flag;
-
-  for (int i = 0; i < MAZESIZE_X; i++) {
-    for (int j = 0; j < MAZESIZE_Y; j++) {
-      steps_map[i][j] = 65535;
-    }
-  }
-  steps_map[x][y] = 0;
-
-  do {
-    change_flag = false;
-    for (int i = 0; i < MAZESIZE_X; i++) {
-      for (int j = 0; j < MAZESIZE_Y; j++) {
-        if (steps_map[i][j] == 65535) continue;
-        if (j < (MAZESIZE_Y - 1)) {
-          if (wall[i][j].north == NOWALL) {
-            if (steps_map[i][j + 1] == 65535) {
-              steps_map[i][j + 1] = steps_map[i][j] + 1;
-              change_flag = true;
-            }
-          }
-        }
-
-        if (i < (MAZESIZE_X - 1)) {
-          if (wall[i][j].east == NOWALL) {
-            if (steps_map[i + 1][j] == 65535) {
-              steps_map[i + 1][j] = steps_map[i][j] + 1;
-              change_flag = true;
-            }
-          }
-        }
-
-        if (j > 0) {
-          if (wall[i][j].south == NOWALL) {
-            if (steps_map[i][j - 1] == 65535) {
-              steps_map[i][j - 1] = steps_map[i][j] + 1;
-              change_flag = true;
-            }
-          }
-        }
-
-        if (i > 0) {
-          if (wall[i][j].west == NOWALL) {
-            if (steps_map[i - 1][j] == 65535) {
-              steps_map[i - 1][j] = steps_map[i][j] + 1;
-              change_flag = true;
-            }
-          }
-        }
-      }
-    }
-  } while (change_flag == true);
-}
-
 void MapManager::makeSearchMap(int x, int y)
 {
   bool change_flag;
@@ -572,6 +516,62 @@ void MapManager::makeSearchMap(int x, int y)
 
         if (i > 0) {
           if (wall[i][j].west != WALL) {
+            if (steps_map[i - 1][j] == 65535) {
+              steps_map[i - 1][j] = steps_map[i][j] + 1;
+              change_flag = true;
+            }
+          }
+        }
+      }
+    }
+  } while (change_flag == true);
+}
+
+void MapManager::makeMap2(int x, int y)
+{
+  bool change_flag;
+
+  for (int i = 0; i < MAZESIZE_X; i++) {
+    for (int j = 0; j < MAZESIZE_Y; j++) {
+      steps_map[i][j] = 65535;
+    }
+  }
+  steps_map[x][y] = 0;
+
+  do {
+    change_flag = false;
+    for (int i = 0; i < MAZESIZE_X; i++) {
+      for (int j = 0; j < MAZESIZE_Y; j++) {
+        if (steps_map[i][j] == 65535) continue;
+        if (j < (MAZESIZE_Y - 1)) {
+          if (wall[i][j].north == NOWALL) {
+            if (steps_map[i][j + 1] == 65535) {
+              steps_map[i][j + 1] = steps_map[i][j] + 1;
+              change_flag = true;
+            }
+          }
+        }
+
+        if (i < (MAZESIZE_X - 1)) {
+          if (wall[i][j].east == NOWALL) {
+            if (steps_map[i + 1][j] == 65535) {
+              steps_map[i + 1][j] = steps_map[i][j] + 1;
+              change_flag = true;
+            }
+          }
+        }
+
+        if (j > 0) {
+          if (wall[i][j].south == NOWALL) {
+            if (steps_map[i][j - 1] == 65535) {
+              steps_map[i][j - 1] = steps_map[i][j] + 1;
+              change_flag = true;
+            }
+          }
+        }
+
+        if (i > 0) {
+          if (wall[i][j].west == NOWALL) {
             if (steps_map[i - 1][j] == 65535) {
               steps_map[i - 1][j] = steps_map[i][j] + 1;
               change_flag = true;


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#11 の追加変更です。
MapManagerクラスのmakeSearchMapとmakeMap2関数の順番を逆にします。

makeSearchMapが初回探索用、makeMap2が最短経路探索用なためです。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
CIでコードがビルドできることを確認します。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
