### PR TITLE
STEP10 controlInterrupt関数のモータオフしきい値、タイヤ角度更新処理の修正

### DIFF
--- a/uROS_STEP10_tfMsg/intrrupt.ino
+++ b/uROS_STEP10_tfMsg/intrrupt.ino
@@ -14,18 +14,18 @@
 
 void controlInterrupt(void)
 {
-  // 直進速度と回転速度から、左右のタイヤ速度を求める
+  // 直進速度と回転速度から、左右のモータ速度を求める
   double speed_r = g_speed + g_omega * TREAD_WIDTH / 2.0;
   double speed_l = g_speed - g_omega * TREAD_WIDTH / 2.0;
 
-  // 左右両方のタイヤ速度がMIN_SPEED以下の場合は走行を停止する
+  // 左右両方のモータ速度がMIN_SPEED以下の場合は走行を停止する
   if (fabs(speed_r) < MIN_SPEED && fabs(speed_l) < MIN_SPEED) {
     g_motor_move = 0;
     return;
   }
 
   g_motor_move = 1;
-  // タイヤの最低速度をMIN_SPEEDに制限する
+  // モータ速度をMIN_SPEED以上に制限する
   if (fabs(speed_r) < MIN_SPEED) {
     speed_r = (speed_r > 0.0) ? MIN_SPEED : -1.0 * MIN_SPEED;
   }
@@ -33,7 +33,7 @@ void controlInterrupt(void)
     speed_l = (speed_l > 0.0) ? MIN_SPEED : -1.0 * MIN_SPEED;
   }
 
-  // 制限されたタイヤ速度から、直進速度と回転速度を求める
+  // 制限されたモータ速度から、直進速度と回転速度を求める
   const double forward_speed = (speed_r + speed_l) / 2.0;
   const double omega = (speed_r - speed_l) / TREAD_WIDTH;
 

--- a/uROS_STEP10_tfMsg/intrrupt.ino
+++ b/uROS_STEP10_tfMsg/intrrupt.ino
@@ -18,9 +18,8 @@ void controlInterrupt(void)
   double speed_r = g_speed + g_omega * TREAD_WIDTH / 2.0;
   double speed_l = g_speed - g_omega * TREAD_WIDTH / 2.0;
 
-  // 左右両方のタイヤ速度がMOTOR_OFF_THRESHOLD以下の場合は走行を停止する
-  const double MOTOR_OFF_THRESHOLD = MIN_SPEED * 0.5;
-  if (fabs(speed_r) < MOTOR_OFF_THRESHOLD && fabs(speed_l) < MOTOR_OFF_THRESHOLD) {
+  // 左右両方のタイヤ速度がMIN_SPEED以下の場合は走行を停止する
+  if (fabs(speed_r) < MIN_SPEED && fabs(speed_l) < MIN_SPEED) {
     g_motor_move = 0;
     return;
   }

--- a/uROS_STEP10_tfMsg/intrrupt.ino
+++ b/uROS_STEP10_tfMsg/intrrupt.ino
@@ -14,34 +14,36 @@
 
 void controlInterrupt(void)
 {
-  double speed_r, speed_l;
+  // 直進速度と回転速度から、左右のタイヤ速度を求める
+  double speed_r = g_speed + g_omega * TREAD_WIDTH / 2.0;
+  double speed_l = g_speed - g_omega * TREAD_WIDTH / 2.0;
 
-  if ((g_speed < 0.001) && (g_speed > -0.001) && (g_omega < 0.001) && (g_omega > -0.001)) {
+  // 左右両方のタイヤ速度がMOTOR_OFF_SPEED以下の場合は走行を停止する
+  const double MOTOR_OFF_SPEED = MIN_SPEED * 0.5;
+  if (fabs(speed_r) < MOTOR_OFF_SPEED && fabs(speed_l) < MOTOR_OFF_SPEED) {
     g_motor_move = 0;
-  } else {
-    g_motor_move = 1;
+    return;
   }
 
-  speed_r = g_speed + g_omega * TREAD_WIDTH / 2.0;
-  speed_l = g_speed - g_omega * TREAD_WIDTH / 2.0;
-
-  if ((speed_r > 0.001) && (speed_r < MIN_SPEED)) {
-    speed_r = MIN_SPEED;
-  } else if ((speed_r < -0.001) && (speed_r > (-1.0 * MIN_SPEED))) {
-    speed_r = -1.0 * MIN_SPEED;
+  g_motor_move = 1;
+  // タイヤの最低速度をMIN_SPEEDに制限する
+  if (fabs(speed_r) < MIN_SPEED) {
+    speed_r = (speed_r > 0.0) ? MIN_SPEED : -1.0 * MIN_SPEED;
   }
-  if ((speed_l > 0.001) && (speed_l < MIN_SPEED)) {
-    speed_l = MIN_SPEED;
-  } else if ((speed_l < -0.001) && (speed_l > (-1.0 * MIN_SPEED))) {
-    speed_l = -1.0 * MIN_SPEED;
+  if (fabs(speed_l) < MIN_SPEED) {
+    speed_l = (speed_l > 0.0) ? MIN_SPEED : -1.0 * MIN_SPEED;
   }
-  g_speed = (speed_r + speed_l) / 2.0;
 
-  g_odom_x += g_speed * 0.001 * cos(g_odom_theta) * 0.001;
-  g_odom_y += g_speed * 0.001 * sin(g_odom_theta) * 0.001;
-  g_odom_theta += g_omega * 0.001;
-  g_position_r += speed_r * 0.001 / (48 * PI) * 2 * PI;
-  g_position_l -= speed_l * 0.001 / (48 * PI) * 2 * PI;
+  // 制限されたタイヤ速度から、直進速度と回転速度を求める
+  const double forward_speed = (speed_r + speed_l) / 2.0;
+  const double omega = (speed_r - speed_l) / TREAD_WIDTH;
+
+  const double UPDATE_INTERVAL = 0.001;
+  g_odom_x += forward_speed * UPDATE_INTERVAL * cos(g_odom_theta) * UPDATE_INTERVAL;
+  g_odom_y += forward_speed * UPDATE_INTERVAL * sin(g_odom_theta) * UPDATE_INTERVAL;
+  g_odom_theta += omega * UPDATE_INTERVAL;
+  g_position_r += speed_r * UPDATE_INTERVAL / (TIRE_DIAMETER * PI) * 2 * PI;
+  g_position_l -= speed_l * UPDATE_INTERVAL / (TIRE_DIAMETER * PI) * 2 * PI;
 
   if (speed_r > 0) {
     digitalWrite(CW_R, LOW);

--- a/uROS_STEP10_tfMsg/intrrupt.ino
+++ b/uROS_STEP10_tfMsg/intrrupt.ino
@@ -18,9 +18,9 @@ void controlInterrupt(void)
   double speed_r = g_speed + g_omega * TREAD_WIDTH / 2.0;
   double speed_l = g_speed - g_omega * TREAD_WIDTH / 2.0;
 
-  // 左右両方のタイヤ速度がMOTOR_OFF_SPEED以下の場合は走行を停止する
-  const double MOTOR_OFF_SPEED = MIN_SPEED * 0.5;
-  if (fabs(speed_r) < MOTOR_OFF_SPEED && fabs(speed_l) < MOTOR_OFF_SPEED) {
+  // 左右両方のタイヤ速度がMOTOR_OFF_THRESHOLD以下の場合は走行を停止する
+  const double MOTOR_OFF_THRESHOLD = MIN_SPEED * 0.5;
+  if (fabs(speed_r) < MOTOR_OFF_THRESHOLD && fabs(speed_l) < MOTOR_OFF_THRESHOLD) {
     g_motor_move = 0;
     return;
   }


### PR DESCRIPTION
モータOFF時にタイヤ角度の更新も止める

<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

controlInterrupt関数の下記の問題を修正します

- モータをオフする最低速度の単位がm/s と mm/sで整合性取れてない。
  - 「タイヤ速度が0.001を下回ったら走行停止」という処理が書かれているが、タイヤ速度の単位はmm/sのため、cmd_velを極小にしないと走行停止しない
- 低速時は実機が止まってもjoint_stateは回転し続ける。

## 修正方法

- モータをオフする最低速度`MIN_SPEED`に統一します。
- 左右のタイヤ速度が`MIN_SPEED`を下回ったらモータをオフし、odomとjointの更新を止めます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

- Pi:Coのサンプルを実行し、cmd_velの直進速度が約0.030 m/sを下回るとモータが停止することを確認しました
- cmd_velを極小にしPi:Co実機が止まると、joint_statesの角度が更新されなくなることを確認しました

# Any other comments?
<!-- その他コメントはありますか？ -->

後ほど別PRでファイル名`interrupt.ino`に修正します。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
