### PR TITLE
map write read BugFix

### DIFF
--- a/uROS_STEP12_micromouse/SPIFFS.ino
+++ b/uROS_STEP12_micromouse/SPIFFS.ino
@@ -30,8 +30,8 @@ void mapWrite(void)
     Serial.println("- failed to open file for writing");
     return;
   }
-  for (int i = 0; i < 16; i++) {
-    for (int j = 0; j < 16; j++) {
+  for (int i = 0; i < MAZESIZE_X; i++) {
+    for (int j = 0; j < MAZESIZE_Y; j++) {
       data_temp = g_map_control.getWallData(i, j, north) +
                   (g_map_control.getWallData(i, j, east) << 2) +
                   (g_map_control.getWallData(i, j, south) << 4) +
@@ -63,8 +63,8 @@ void copyMap(void)
     Serial.println("- failed to open file for reading");
     return;
   }
-  for (int i = 0; i < 16; i++) {
-    for (int j = 0; j < 16; j++) {
+  for (int i = 0; i < MAZESIZE_X; i++) {
+    for (int j = 0; j < MAZESIZE_Y; j++) {
       if (file.available()) {
         read_data = file.read();
         g_map_control.setWallData(i, j, north, read_data & 0x03);

--- a/uROS_STEP2_SWITCH/uROS_STEP2_SWITCH.ino
+++ b/uROS_STEP2_SWITCH/uROS_STEP2_SWITCH.ino
@@ -49,7 +49,7 @@ void loop()
   }
   if (digitalRead(SW_C) == 0) {
     digitalWrite(LED2, (++g_state_c) & 0x01);
-    digitalWrite(LED1, (g_state_c)&0x01);
+    digitalWrite(LED1, g_state_c & 0x01);
   }
   if (digitalRead(SW_L) == 0) {
     digitalWrite(LED0, (++g_state_l) & 0x01);

--- a/uROS_STEP8_micromouse/SPIFFS.ino
+++ b/uROS_STEP8_micromouse/SPIFFS.ino
@@ -30,8 +30,8 @@ void mapWrite(void)
     Serial.println("- failed to open file for writing");
     return;
   }
-  for (int i = 0; i < 16; i++) {
-    for (int j = 0; j < 16; j++) {
+  for (int i = 0; i < MAZESIZE_X; i++) {
+    for (int j = 0; j < MAZESIZE_Y; j++) {
       data_temp = g_map_control.getWallData(i, j, north) +
                   (g_map_control.getWallData(i, j, east) << 2) +
                   (g_map_control.getWallData(i, j, south) << 4) +
@@ -63,8 +63,8 @@ void copyMap(void)
     Serial.println("- failed to open file for reading");
     return;
   }
-  for (int i = 0; i < 16; i++) {
-    for (int j = 0; j < 16; j++) {
+  for (int i = 0; i < MAZESIZE_X; i++) {
+    for (int j = 0; j < MAZESIZE_Y; j++) {
       if (file.available()) {
         read_data = file.read();
         g_map_control.setWallData(i, j, north, read_data & 0x03);


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
バグの現象  
MapManager.hにある迷路マップのサイズのMAPSIZE_X、MAPSIZE_Yを16以外にした時、flashROMの書き込みを失敗する  
修正内容  
SPIFFSのマップの読み書きを16で固定してたものをMAPSIZE_X、MAPSIZE_Yに変更した  

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
ありません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
MAPSIZE_X、MAPSIZE_Yを4にし、4x4の迷路で実機で試しました

# Any other comments?
<!-- その他コメントはありますか？ -->
対象はSTEP8とSTEP12

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [ x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
